### PR TITLE
INT-3634 - Leverage new Detectify endpoints

### DIFF
--- a/src/converter/entities.ts
+++ b/src/converter/entities.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   createIntegrationEntity,
-  getTime,
   convertProperties,
   Entity,
+  parseTimePropertyValue,
 } from '@jupiterone/integration-sdk-core';
 import {
   getHostnameFromUrl,
@@ -13,8 +12,12 @@ import {
 } from './utils';
 import { Entities } from '../constants';
 
+export function buildAccountEntityKey(integrationInstanceId: string) {
+  return `detectify:account:${integrationInstanceId}`;
+}
+
 export const getAccountEntity = (instance: any): Entity => ({
-  _key: `detectify:account:${instance.id}`,
+  _key: buildAccountEntityKey(instance.id),
   _type: Entities.ACCOUNT._type,
   _class: Entities.ACCOUNT._class,
   name: instance.name,
@@ -22,8 +25,12 @@ export const getAccountEntity = (instance: any): Entity => ({
   description: instance.description,
 });
 
+export function buildServiceEntityKey(integrationInstanceId: string) {
+  return `detectify:service:${integrationInstanceId}:mast`;
+}
+
 export const getServiceEntity = (instance: any): Entity => ({
-  _key: `detectify:service:${instance.id}:mast`,
+  _key: buildServiceEntityKey(instance.id),
   _type: Entities.SERVICE._type,
   _class: Entities.SERVICE._class,
   name: 'Detectify DAST',
@@ -45,14 +52,18 @@ export const convertDomain = (
         _type: Entities.WEB_APP_DOMAIN._type,
         _class: Entities.WEB_APP_DOMAIN._class,
         displayName: data.name,
-        createdOn: getTime(data.created),
-        updatedOn: getTime(data.updated),
+        createdOn: parseTimePropertyValue(data.created),
+        updatedOn: parseTimePropertyValue(data.updated),
         status: data.status,
         token: data.token,
         monitored: data.monitored,
       },
     },
   });
+
+export function getSubdomainEntityKey(subdomainName: string) {
+  return `web-app-endpoint:${subdomainName}`;
+}
 
 export const convertSubdomain = (
   data: any,
@@ -61,17 +72,18 @@ export const convertSubdomain = (
     entityData: {
       source: data,
       assign: {
-        _key: `web-app-endpoint:${data.name}`,
+        _key: getSubdomainEntityKey(data.name),
         _type: Entities.WEB_APP_ENDPOINT._type,
         _class: Entities.WEB_APP_ENDPOINT._class,
         name: data.name,
         displayName: data.name,
         address: data.name,
-        createdOn: getTime(data.discovered),
-        updatedOn: getTime(data.updated),
-        lastSeenOn: getTime(data.last_seen),
+        createdOn: parseTimePropertyValue(data.discovered),
+        updatedOn: parseTimePropertyValue(data.updated),
+        lastSeenOn: parseTimePropertyValue(data.last_seen),
         status: data.status,
         token: data.token,
+        addedBy: data.added_by,
       },
     },
   });
@@ -89,7 +101,7 @@ export const convertProfile = (
         name: data.name,
         displayName: data.name,
         endpoint: data.endpoint,
-        createdOn: getTime(data.created),
+        createdOn: parseTimePropertyValue(data.created),
         status: data.status,
         token: data.token,
       },
@@ -111,9 +123,9 @@ export const convertReport = (
         category: 'Vulnerability Scan',
         summary: buildReportSummary(data),
         endpoint: data.endpoint,
-        createdOn: getTime(data.created),
-        startedOn: getTime(data.started),
-        stoppedOn: getTime(data.stopped),
+        createdOn: parseTimePropertyValue(data.created),
+        startedOn: parseTimePropertyValue(data.started),
+        stoppedOn: parseTimePropertyValue(data.stopped),
         cvss: data.cvss,
         score: data.cvss,
         scanProfileName: data.scan_profile_name,
@@ -156,7 +168,7 @@ export const convertFinding = (
         endpoint: data.found_at?.startsWith('http')
           ? getHostnameFromUrl(data.found_at)
           : data.found_at,
-        createdOn: getTime(data.start_timestamp),
+        createdOn: parseTimePropertyValue(data.start_timestamp),
         details: data.details?.map((d) => d.value),
         references: data.definition?.references?.map((r) => r.link),
         cvss2Score,

--- a/src/steps/fetch-assets/index.ts
+++ b/src/steps/fetch-assets/index.ts
@@ -3,16 +3,128 @@ import {
   IntegrationStepExecutionContext,
   createDirectRelationship,
   RelationshipClass,
+  IntegrationError,
 } from '@jupiterone/integration-sdk-core';
 
 import { createServicesClient } from '../../collector';
 import {
   convertDomain,
   convertSubdomain,
-  getServiceEntity,
-  getAccountEntity,
+  buildServiceEntityKey,
+  buildAccountEntityKey,
 } from '../../converter';
 import { Entities, Steps, Relationships } from '../../constants';
+
+async function fetchRootDomains({
+  instance,
+  jobState,
+}: IntegrationStepExecutionContext) {
+  const client = createServicesClient(instance);
+
+  await client.iterateRootDomains(async (domainAsset) => {
+    await jobState.addEntity(convertDomain(domainAsset));
+  });
+}
+
+async function buildServiceDomainRelationships({
+  instance,
+  jobState,
+}: IntegrationStepExecutionContext) {
+  const serviceEntity = await jobState.findEntity(
+    buildServiceEntityKey(instance.id),
+  );
+
+  if (!serviceEntity) {
+    throw new IntegrationError({
+      message: 'Could not find service entity in job state',
+      code: 'MISSING_ENTITY',
+      fatal: true,
+    });
+  }
+
+  await jobState.iterateEntities(
+    {
+      _type: Entities.WEB_APP_DOMAIN._type,
+    },
+    async (domainEntity) => {
+      await jobState.addRelationship(
+        createDirectRelationship({
+          from: serviceEntity,
+          to: domainEntity,
+          _class: RelationshipClass.SCANS,
+        }),
+      );
+    },
+  );
+}
+
+async function buildAccountDomainRelationships({
+  instance,
+  jobState,
+}: IntegrationStepExecutionContext) {
+  const accountEntity = await jobState.findEntity(
+    buildAccountEntityKey(instance.id),
+  );
+
+  if (!accountEntity) {
+    throw new IntegrationError({
+      message: 'Could not find account entity in job state',
+      code: 'MISSING_ENTITY',
+      fatal: true,
+    });
+  }
+
+  await jobState.iterateEntities(
+    {
+      _type: Entities.WEB_APP_DOMAIN._type,
+    },
+    async (domainEntity) => {
+      await jobState.addRelationship(
+        createDirectRelationship({
+          from: accountEntity,
+          to: domainEntity,
+          _class: RelationshipClass.HAS,
+        }),
+      );
+    },
+  );
+}
+
+async function fetchSubdomainsForRootDomains({
+  instance,
+  jobState,
+}: IntegrationStepExecutionContext) {
+  const client = createServicesClient(instance);
+
+  await jobState.iterateEntities(
+    {
+      _type: Entities.WEB_APP_DOMAIN._type,
+    },
+    async (domainEntity) => {
+      const domainEntityToken = domainEntity.token as string;
+      if (!domainEntityToken) return;
+
+      await client.iterateSubdomains(
+        domainEntityToken,
+        async (subdomainAsset) => {
+          const subdomainEntity = await jobState.addEntity(
+            convertSubdomain(subdomainAsset),
+          );
+
+          // NOTE: This is in the same step to avoid needing to create an
+          // index on the subdomains for each domain
+          await jobState.addRelationship(
+            createDirectRelationship({
+              from: domainEntity,
+              to: subdomainEntity,
+              _class: RelationshipClass.HAS,
+            }),
+          );
+        },
+      );
+    },
+  );
+}
 
 const step: IntegrationStep = {
   id: Steps.ASSETS,
@@ -23,54 +135,12 @@ const step: IntegrationStep = {
     Relationships.ACCOUNT_HAS_DOMAIN,
     Relationships.DOMAIN_HAS_SUBDOMAIN,
   ],
-  async executionHandler({
-    instance,
-    jobState,
-  }: IntegrationStepExecutionContext) {
-    const client = createServicesClient(instance);
-
-    const domains = await client.getRootDomains();
-    const domainEntities = domains.map(convertDomain);
-    await jobState.addEntities(domainEntities);
-
-    const serviceEntity = getServiceEntity(instance);
-    const serviceRelationships = domainEntities.map((domainEntity) =>
-      createDirectRelationship({
-        from: serviceEntity,
-        to: domainEntity,
-        _class: RelationshipClass.SCANS,
-      }),
-    );
-    await jobState.addRelationships(serviceRelationships);
-
-    const accountEntity = getAccountEntity(instance);
-    const accountRelationships = domainEntities.map((domainEntity) =>
-      createDirectRelationship({
-        from: accountEntity,
-        to: domainEntity,
-        _class: RelationshipClass.HAS,
-      }),
-    );
-    await jobState.addRelationships(accountRelationships);
-
-    for (const domainEntity of domainEntities) {
-      if (domainEntity.token) {
-        const subdomains = await client.getSubDomains(
-          domainEntity.token as any,
-        );
-        const subdomainEntities = subdomains.map(convertSubdomain);
-        await jobState.addEntities(subdomainEntities);
-
-        const endpointRelationships = subdomainEntities.map((subdomainEntity) =>
-          createDirectRelationship({
-            from: domainEntity,
-            to: subdomainEntity,
-            _class: RelationshipClass.HAS,
-          }),
-        );
-        await jobState.addRelationships(endpointRelationships);
-      }
-    }
+  dependsOn: [Steps.ACCOUNT],
+  async executionHandler(context: IntegrationStepExecutionContext) {
+    await fetchRootDomains(context);
+    await buildServiceDomainRelationships(context);
+    await buildAccountDomainRelationships(context);
+    await fetchSubdomainsForRootDomains(context);
   },
 };
 

--- a/src/steps/fetch-findings/index.ts
+++ b/src/steps/fetch-findings/index.ts
@@ -2,63 +2,77 @@ import {
   IntegrationStep,
   IntegrationStepExecutionContext,
   createDirectRelationship,
-  Relationship,
   RelationshipClass,
+  JobState,
 } from '@jupiterone/integration-sdk-core';
 
 import { createServicesClient } from '../../collector';
-import { convertFinding } from '../../converter';
+import { convertFinding, getSubdomainEntityKey } from '../../converter';
 import { Entities, Steps, Relationships } from '../../constants';
 
 const MS_IN_A_DAY = 86400000;
 const DAYS_TO_GET = 30;
+
+function getFindingsFromTimestamp() {
+  const now = new Date().getTime();
+  return (new Date(now - MS_IN_A_DAY * DAYS_TO_GET).getTime() / 1000) | 0;
+}
+
+async function domainFindingIteratee(jobState: JobState, domainFinding: any) {
+  const findingEntity = await jobState.addEntity(convertFinding(domainFinding));
+
+  const findingEntityEndpoint = findingEntity.endpoint as string;
+  if (!findingEntityEndpoint) return;
+
+  const subdomainEntity = await jobState.findEntity(
+    getSubdomainEntityKey(findingEntityEndpoint),
+  );
+
+  if (!subdomainEntity) return;
+
+  await jobState.addRelationship(
+    createDirectRelationship({
+      from: subdomainEntity,
+      to: findingEntity,
+      _class: RelationshipClass.HAS,
+    }),
+  );
+}
 
 const step: IntegrationStep = {
   id: Steps.FINDINGS,
   name: `Fetch Detectify findings from past ${DAYS_TO_GET} days`,
   entities: [Entities.FINDING],
   relationships: [Relationships.ENDPOINT_HAS_FINDING],
+  dependsOn: [Steps.ASSETS],
   async executionHandler({
     instance,
     jobState,
   }: IntegrationStepExecutionContext) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((instance.config as any).getLatestScanFindings) {
-      return;
-    }
+    if (!instance.config.getLatestScanFindings) return;
 
     const client = createServicesClient(instance);
-    const domains = await client.getRootDomains();
+    const fromDateString = getFindingsFromTimestamp().toString();
 
-    const now = new Date().getTime();
-    const from =
-      (new Date(now - MS_IN_A_DAY * DAYS_TO_GET).getTime() / 1000) | 0;
+    await jobState.iterateEntities(
+      {
+        _type: Entities.WEB_APP_DOMAIN._type,
+      },
+      async (domainEntity) => {
+        const domainEntityToken = domainEntity.token as string;
+        if (!domainEntityToken) return;
 
-    for (const domain of domains) {
-      if (domain.token) {
-        const findings = await client.getDomainFindings(domain.token, {
-          from: from.toString(),
+        await client.iterateDomainFindings({
+          token: domainEntityToken,
+          queryParams: {
+            from: fromDateString,
+          },
+          async iteratee(domainFinding) {
+            await domainFindingIteratee(jobState, domainFinding);
+          },
         });
-        const findingEntities = findings.map(convertFinding);
-        await jobState.addEntities(findingEntities);
-
-        const relationships: Relationship[] = [];
-        findingEntities.forEach((findingEntity) => {
-          if (findingEntity.endpoint) {
-            relationships.push(
-              createDirectRelationship({
-                fromType: Entities.WEB_APP_ENDPOINT._type,
-                fromKey: `web-app-endpoint:${findingEntity.endpoint}`,
-                toType: findingEntity._type,
-                toKey: findingEntity._key,
-                _class: RelationshipClass.HAS,
-              }),
-            );
-          }
-        });
-        await jobState.addRelationships(relationships);
-      }
-    }
+      },
+    );
   },
 };
 

--- a/src/steps/fetch-scan-profiles/index.ts
+++ b/src/steps/fetch-scan-profiles/index.ts
@@ -14,38 +14,41 @@ const step: IntegrationStep = {
   name: 'Fetch Detectify scan reports',
   entities: [Entities.SCAN_PROFILE],
   relationships: [Relationships.DOMAIN_HAS_SCAN_PROFILE],
+  dependsOn: [Steps.ASSETS],
   async executionHandler({
     instance,
     jobState,
   }: IntegrationStepExecutionContext) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (!(instance.config as any).getLatestScanFindings) {
-      return;
-    }
-
+    if (!instance.config.getLatestScanFindings) return;
     const client = createServicesClient(instance);
-    const domains = await client.getRootDomains();
 
-    for (const domain of domains) {
-      if (domain.token) {
-        const profiles = await client.getScanProfiles(domain.token);
+    await jobState.iterateEntities(
+      {
+        _type: Entities.WEB_APP_DOMAIN._type,
+      },
+      async (domainEntity) => {
+        const domainEntityToken = domainEntity.token as string;
+        if (!domainEntityToken) return;
+
+        const profiles = await client.getScanProfiles(domainEntityToken);
         const profileEntities = profiles.map(convertProfile);
         await jobState.addEntities(profileEntities);
 
         for (const profileEntity of profileEntities) {
-          if (profileEntity.token) {
-            const scanProfileRelationship = createDirectRelationship({
+          if (!profileEntity.token) continue;
+
+          await jobState.addRelationship(
+            createDirectRelationship({
               fromType: Entities.WEB_APP_DOMAIN._type,
-              fromKey: `web-app-domain:${domain.name}`,
+              fromKey: `web-app-domain:${domainEntity.name}`,
               toType: profileEntity._type,
               toKey: profileEntity._key,
               _class: RelationshipClass.HAS,
-            });
-            await jobState.addRelationship(scanProfileRelationship);
-          }
+            }),
+          );
         }
-      }
-    }
+      },
+    );
   },
 };
 


### PR DESCRIPTION
Detectify has deprecated and ended life of several endpoints. This
change updates the integration to use the new API endpoints.

Deprecated: `GET /domains/`
Replaced with: `GET /assets/`

Deprecated: `GET /domains/{domainToken}/subdomains/`
Replaced with: `GET /assets/{assetToken}/subdomains/`

Deprecated: `GET /domains/{domainToken}/findings/`
Replaced with: `GET /domains/{domainToken}/findings/paginated/`